### PR TITLE
Fix warnings / fix duplicate symbols

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Triangle
    )
 
 option(TRIANGLE_ENABLE_ACUTE "Enable the aCute extension." ON)
-
+option(BUILD_SHARED_LIBS "Build libraries as shared libraries." ON)
 option(BUILD_TESTING "Enable unit tests." ON)
 if(BUILD_TESTING)
    enable_testing()

--- a/src/Triangle/CMakeLists.txt
+++ b/src/Triangle/CMakeLists.txt
@@ -31,8 +31,7 @@ set_property(TARGET triangle PROPERTY VERSION ${Triangle_VERSION})
 set_property(TARGET triangle PROPERTY SOVERSION 1)
 
 # triangle-api is the "modern" interface:
-# force shared library for now, because otherwise check_behavior is defined and clashes with another define in triangle-cli
-add_library(triangle-api SHARED
+add_library(triangle-api
    triangle_api.c
    triangle_helper.c
    )

--- a/src/Triangle/acute.c
+++ b/src/Triangle/acute.c
@@ -2391,7 +2391,7 @@ int getWedgeIntersectionWithoutMaxAngle(mesh *m, behavior *b,
 	if(i == 0){
 		// line1 & line2: p1
 		lineLineIntersection(x0, y0, x_1, y_1, x1, y1, x_2, y_2, p1);		
-		if((p1[0] == 1.0)){			
+		if(p1[0] == 1.0){
 			// #0
 			initialConvexPoly[0] = p1[1]; initialConvexPoly[1] = p1[2];
 			// #1

--- a/src/Triangle/private/triangle_helper.h
+++ b/src/Triangle/private/triangle_helper.h
@@ -7,6 +7,6 @@ int check_context(context* c);
 int check_behavior(behavior* b);
 int check_triangleio(triangleio* io, int firstnumber);
 
-int restore_pointmarkers(context* ctx, int *pointmarkers);
+void restore_pointmarkers(context* ctx, int *pointmarkers);
 
 #endif /* TRIANGLE_HELPER_H */

--- a/src/Triangle/private/triangle_helper.h
+++ b/src/Triangle/private/triangle_helper.h
@@ -3,10 +3,10 @@
 
 #include "../triangle_api.h"
 
-int check_context(context* c);
-int check_behavior(behavior* b);
-int check_triangleio(triangleio* io, int firstnumber);
+int triangle_check_context(context* c);
+int triangle_check_behavior(behavior* b);
+int triangle_check_triangleio(triangleio* io, int firstnumber);
 
-void restore_pointmarkers(context* ctx, int *pointmarkers);
+void triangle_restore_pointmarkers(context* ctx, int *pointmarkers);
 
 #endif /* TRIANGLE_HELPER_H */

--- a/src/Triangle/triangle.c
+++ b/src/Triangle/triangle.c
@@ -8103,13 +8103,6 @@ int quality_statistics(mesh *m, behavior *b, quality *q)
   int acutebiggest;
   int i, ii, j, k;
 
-  if (q->angletable == NULL) {
-    return -1;
-  }
-  if (q->aspecttable == NULL) {
-    return -1;
-  }
-
   radconst = PI / 18.0;
   degconst = 180.0 / PI;
   for (i = 0; i < 8; i++) {

--- a/src/Triangle/triangle_api.c
+++ b/src/Triangle/triangle_api.c
@@ -37,7 +37,7 @@ context* triangle_context_create()
 
 void triangle_context_destroy(context* ctx)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return;
 	}
 
@@ -51,18 +51,18 @@ void triangle_context_destroy(context* ctx)
 
 int triangle_context_options(context* ctx, char *options)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
 	parsecommandline(options, ctx->b);
 
-	return check_behavior(ctx->b);
+	return triangle_check_behavior(ctx->b);
 }
 
 void triangle_context_get_behavior(context* ctx, behavior *out)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return;
 	}
 
@@ -71,7 +71,7 @@ void triangle_context_get_behavior(context* ctx, behavior *out)
 
 int triangle_context_set_behavior(context* ctx, behavior *in)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -79,12 +79,12 @@ int triangle_context_set_behavior(context* ctx, behavior *in)
 
 	behavior_update(ctx->b);
 
-	return check_behavior(in);
+	return triangle_check_behavior(in);
 }
 
 int triangle_mesh_quality(context* ctx, quality *q)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -96,7 +96,7 @@ int triangle_mesh_statistics(context* ctx, statistics *s)
 	mesh *m;
 	behavior *b;
 
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -127,7 +127,7 @@ int triangle_memory(context* ctx)
 {
 	mesh *m;
 
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -145,7 +145,7 @@ int triangle_memory(context* ctx)
 
 int triangle_check_mesh(context *ctx)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -154,7 +154,7 @@ int triangle_check_mesh(context *ctx)
 
 int triangle_check_delaunay(context *ctx)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -168,7 +168,7 @@ int triangle_mesh_create(context* ctx, triangleio *in)
 
 	int status = 0;
 
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -249,7 +249,7 @@ int triangle_mesh_load(context* ctx, triangleio *in)
 
 	int status = 0;
 
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -319,7 +319,7 @@ int triangle_mesh_refine(context* ctx)
 
 	int status = 0;
 
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -350,7 +350,7 @@ int triangle_mesh_copy(context* ctx, triangleio *out,
 
 	int status = 0;
 
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -404,7 +404,7 @@ int triangle_mesh_copy(context* ctx, triangleio *out,
 	}
 
 	if (out->pointmarkerlist != NULL) {
-		restore_pointmarkers(ctx, out->pointmarkerlist);
+		triangle_restore_pointmarkers(ctx, out->pointmarkerlist);
 	}
 
 	return status;
@@ -419,7 +419,7 @@ void triangle_free(VOID *memptr)
 
 int triangle_write_nodes(context *ctx, FILE *file)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -428,7 +428,7 @@ int triangle_write_nodes(context *ctx, FILE *file)
 
 int triangle_write_elements(context *ctx, FILE *file)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -438,7 +438,7 @@ int triangle_write_elements(context *ctx, FILE *file)
 int triangle_write_poly(context *ctx, FILE *file,
 						REAL *holelist, int holes, REAL *regionlist, int regions)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -448,7 +448,7 @@ int triangle_write_poly(context *ctx, FILE *file,
 
 int triangle_write_edges(context *ctx, FILE *file)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -457,7 +457,7 @@ int triangle_write_edges(context *ctx, FILE *file)
 
 int triangle_write_neighbors(context *ctx, FILE *file)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 
@@ -466,7 +466,7 @@ int triangle_write_neighbors(context *ctx, FILE *file)
 
 int triangle_write_eps(context *ctx, FILE *file)
 {
-	if (check_context(ctx) < 0) {
+	if (triangle_check_context(ctx) < 0) {
 		return TRI_NULL;
 	}
 

--- a/src/Triangle/triangle_helper.c
+++ b/src/Triangle/triangle_helper.c
@@ -74,7 +74,7 @@ int check_triangleio(triangleio* io, int firstnumber)
 	return TRI_OK;
 }
 
-int restore_pointmarkers(context* ctx, int *pointmarkers)
+void restore_pointmarkers(context* ctx, int *pointmarkers)
 {
 	mesh *m;
 	behavior *b;

--- a/src/Triangle/triangle_helper.c
+++ b/src/Triangle/triangle_helper.c
@@ -2,7 +2,7 @@
 #include "triangle_helper.h"
 #include "triangle_internal.h"
 
-int check_context(context* ctx)
+int triangle_check_context(context* ctx)
 {
 	if (ctx == NULL) {
 		return TRI_FAILURE;
@@ -14,7 +14,7 @@ int check_context(context* ctx)
 	return TRI_OK;
 }
 
-int check_behavior(behavior* b)
+int triangle_check_behavior(behavior* b)
 {
 	if (b->fixedarea && b->maxarea <= 0.0) {
 		return TRI_OPTIONS;
@@ -22,7 +22,7 @@ int check_behavior(behavior* b)
 	return TRI_OK;
 }
 
-int check_triangleio(triangleio* io, int firstnumber)
+int triangle_check_triangleio(triangleio* io, int firstnumber)
 {
 	int i;
 	int a, b, c;
@@ -74,7 +74,7 @@ int check_triangleio(triangleio* io, int firstnumber)
 	return TRI_OK;
 }
 
-void restore_pointmarkers(context* ctx, int *pointmarkers)
+void triangle_restore_pointmarkers(context* ctx, int *pointmarkers)
 {
 	mesh *m;
 	behavior *b;


### PR DESCRIPTION
The first two commits just fix compiler warnings with clang.
The third commit fixes the duplicate symbol "check_context" that prevented static builds of triangle-api.
The last commit just makes the now possible choice between static and shared visible.