### PR TITLE
User-defined refinement criterion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,12 @@ option(BUILD_TESTING "Enable unit tests." ON)
 if(BUILD_TESTING)
    enable_testing()
 endif()
+option(BUILD_EXAMPLES "Enable examples." ON)
+if(BUILD_EXAMPLES)
+   add_subdirectory(examples)
+endif()
 
 add_subdirectory(Triangle)
-add_subdirectory(examples)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/src/Triangle/private/triangle_internal.h
+++ b/src/Triangle/private/triangle_internal.h
@@ -6,18 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/********* User-defined triangle evaluation routine begins here      *********/
-/**                                                                         **/
-
-/**
- * Determine if a triangle is unsuitable, and thus must be further refined.
- */
-int triunsuitable(vertex triorg, vertex tridest, vertex triapex, REAL area);
-
-
-/**                                                                         **/
-/********* User-defined triangle evaluation routine ends here        *********/
-
 void interpolate(vertex newvertex, vertex org, vertex dest, vertex apex, int nextras);
 
 void behavior_update(behavior *b);

--- a/src/Triangle/triangle.c
+++ b/src/Triangle/triangle.c
@@ -326,41 +326,26 @@ void behavior_update(behavior *b)
 /*                                                                           */
 /*****************************************************************************/
 
-#ifdef EXTERNAL_TEST
+/*****************************************************************************/
+/*  Symbol EXTERNAL_TEST was removed. Function 'triunsuitable' can now be    */
+/*  can now by assigning the 'triunsuitable_user_func' function ptr.         */
+/*  Please note that the user function is only used if the 'u' program       */
+/*  is set.                                                                  */
+/*****************************************************************************/
 
-int triunsuitable();
+int (*triunsuitable_user_func)(vertex, vertex, vertex, REAL) = NULL;
 
-#else /* not EXTERNAL_TEST */
+void triangle_set_triunsuitable_user_func(int(*func)(vertex, vertex, vertex, REAL))
+{
+  triunsuitable_user_func = func;
+}
 
 int triunsuitable(vertex triorg, vertex tridest, vertex triapex, REAL area)
 {
-  REAL dxoa, dxda, dxod;
-  REAL dyoa, dyda, dyod;
-  REAL oalen, dalen, odlen;
-  REAL maxlen;
-
-  dxoa = triorg[0] - triapex[0];
-  dyoa = triorg[1] - triapex[1];
-  dxda = tridest[0] - triapex[0];
-  dyda = tridest[1] - triapex[1];
-  dxod = triorg[0] - tridest[0];
-  dyod = triorg[1] - tridest[1];
-  /* Find the squares of the lengths of the triangle's three edges. */
-  oalen = dxoa * dxoa + dyoa * dyoa;
-  dalen = dxda * dxda + dyda * dyda;
-  odlen = dxod * dxod + dyod * dyod;
-  /* Find the square of the length of the longest edge. */
-  maxlen = (dalen > oalen) ? dalen : oalen;
-  maxlen = (odlen > maxlen) ? odlen : maxlen;
-
-  if (maxlen > 0.05 * (triorg[0] * triorg[0] + triorg[1] * triorg[1]) + 0.02) {
-    return 1;
-  } else {
-    return 0;
-  }
+  if (triunsuitable_user_func)
+    return triunsuitable_user_func(triorg, tridest, triapex, area);
+  return 0;
 }
-
-#endif /* not EXTERNAL_TEST */
 
 /**                                                                         **/
 /**                                                                         **/
@@ -7381,7 +7366,7 @@ void splittriangle(mesh *m, behavior *b,
     /* Create a new vertex at the triangle's circumcenter. */
     newvertex = (vertex) poolalloc(&m->vertices);
 #ifndef NO_ACUTE
-    if (b->fixedarea || b->vararea) {
+    if (b->fixedarea || b->vararea || b->usertest) {
       // TODO: Acute fails for certain area constraints.
       findcircumcenter(m, b, borg, bdest, bapex, newvertex, &xi, &eta, 1);
     } else {

--- a/src/Triangle/triangle.c
+++ b/src/Triangle/triangle.c
@@ -299,58 +299,6 @@ void behavior_update(behavior *b)
 /**                                                                         **/
 /********* Triangle utility functions end here                       *********/
 
-/********* User-defined triangle evaluation routine begins here      *********/
-/**                                                                         **/
-/**                                                                         **/
-
-/*****************************************************************************/
-/*                                                                           */
-/*  triunsuitable()   Determine if a triangle is unsuitable, and thus must   */
-/*                    be further refined.                                    */
-/*                                                                           */
-/*  You may write your own procedure that decides whether or not a selected  */
-/*  triangle is too big (and needs to be refined).  There are two ways to do */
-/*  this.                                                                    */
-/*                                                                           */
-/*  (1)  Modify the procedure `triunsuitable' below, then recompile          */
-/*  Triangle.                                                                */
-/*                                                                           */
-/*  (2)  Define the symbol EXTERNAL_TEST (either by adding the definition    */
-/*  to this file, or by using the appropriate compiler switch).  This way,   */
-/*  you can compile triangle.c separately from your test.  Write your own    */
-/*  `triunsuitable' procedure in a separate C file (using the same prototype */
-/*  as below).  Compile it and link the object code with triangle.o.         */
-/*                                                                           */
-/*  This procedure returns 1 if the triangle is too large and should be      */
-/*  refined; 0 otherwise.                                                    */
-/*                                                                           */
-/*****************************************************************************/
-
-/*****************************************************************************/
-/*  Symbol EXTERNAL_TEST was removed. Function 'triunsuitable' can now be    */
-/*  can now by assigning the 'triunsuitable_user_func' function ptr.         */
-/*  Please note that the user function is only used if the 'u' program       */
-/*  is set.                                                                  */
-/*****************************************************************************/
-
-int (*triunsuitable_user_func)(vertex, vertex, vertex, REAL) = NULL;
-
-void triangle_set_triunsuitable_user_func(int(*func)(vertex, vertex, vertex, REAL))
-{
-  triunsuitable_user_func = func;
-}
-
-int triunsuitable(vertex triorg, vertex tridest, vertex triapex, REAL area)
-{
-  if (triunsuitable_user_func)
-    return triunsuitable_user_func(triorg, tridest, triapex, area);
-  return 0;
-}
-
-/**                                                                         **/
-/**                                                                         **/
-/********* User-defined triangle evaluation routine ends here        *********/
-
 /********* Memory allocation and program exit wrappers begin here    *********/
 /**                                                                         **/
 /**                                                                         **/
@@ -2104,7 +2052,7 @@ void testtriangle(mesh *m, behavior *b, struct otri *testtri)
 
     if (b->usertest) {
       /* Check whether the user thinks this triangle is too large. */
-      if (triunsuitable(torg, tdest, tapex, area)) {
+      if (b->triunsuitable_user_func && b->triunsuitable_user_func(torg, tdest, tapex, area)) {
         enqueuebadtri(m, b, testtri, minedge, tapex, torg, tdest);
         return;
       }

--- a/src/Triangle/triangle.h
+++ b/src/Triangle/triangle.h
@@ -462,6 +462,11 @@ typedef struct behavior_t {
   /* Cosine of maxangle. */
   REAL maxgoodangle;
 #endif
+
+  /* Callback function for user-defined mesh sizing. */
+  /* Arguments are int (vertex triorg, vertex tridest, vertex triapex, REAL area) */
+  /* Should return 1 if triangle has to be further refined or 0 if not. */
+  int (*triunsuitable_user_func)(vertex, vertex, vertex, REAL);
 } behavior;                                     /* End of `struct behavior'. */
 
 /* Forward declaration of acute memorypool struct */

--- a/src/Triangle/triangle_api.c
+++ b/src/Triangle/triangle_api.c
@@ -32,6 +32,10 @@ context* triangle_context_create()
 	m->dummysub = NULL;
 	m->dummysubbase = NULL;
 
+	/* Initialize triunsuitable user function to zero. */
+
+	b->triunsuitable_user_func = NULL;
+
 	return ctx;
 }
 

--- a/src/Triangle/triangle_api.h
+++ b/src/Triangle/triangle_api.h
@@ -229,15 +229,6 @@ extern "C" {
 	 */
 	EXPORT int triangle_read_area(const char* filename, triangleio *io);
 
-	/**
-	 * Set user func to steer mesh refinement. Function will only be invoked if the 'u' program
-	 * option is set.
-	 * @param func Callback function pointer. Takes three coordinates associated with a triangle and
-	 *        the triangle's area. Function pointer should 1 if the triangle should be refined
-	 *        further and 0 otherwise.
-	 */
-	EXPORT void triangle_set_triunsuitable_user_func(int(*func)(vertex, vertex, vertex, REAL));
-
 #endif /* NO_FILE_IO */
 
 #ifdef __cplusplus

--- a/src/Triangle/triangle_api.h
+++ b/src/Triangle/triangle_api.h
@@ -228,6 +228,16 @@ extern "C" {
 	 * @return Integer status code.
 	 */
 	EXPORT int triangle_read_area(const char* filename, triangleio *io);
+
+	/**
+	 * Set user func to steer mesh refinement. Function will only be invoked if the 'u' program
+	 * option is set.
+	 * @param func Callback function pointer. Takes three coordinates associated with a triangle and
+	 *        the triangle's area. Function pointer should 1 if the triangle should be refined
+	 *        further and 0 otherwise.
+	 */
+	EXPORT void triangle_set_triunsuitable_user_func(int(*func)(vertex, vertex, vertex, REAL));
+
 #endif /* NO_FILE_IO */
 
 #ifdef __cplusplus

--- a/src/examples/triangle-cli/README.txt
+++ b/src/examples/triangle-cli/README.txt
@@ -110,14 +110,20 @@ Command Line Switches Details:
         constraint by invoking the -a switch twice, once with and once
         without a number following.  Each area specified may include a
         decimal point.
-    -u  Imposes a user-defined constraint on triangle size.  There are two
-        ways to use this feature.  One is to edit the triunsuitable()
-        procedure in triangle.c to encode any constraint you like, then
-        recompile Triangle.  The other is to compile triangle.c with the
-        EXTERNAL_TEST symbol set (compiler switch -DEXTERNAL_TEST), then
-        link Triangle with a separate object file that implements
-        triunsuitable().  In either case, the -u switch causes the user-
-        defined test to be applied to every triangle.
+    -u  Imposes a user-defined constraint on the triangle size. The
+        constraint can be defined by setting the function pointer in the
+        behavior struct of the context, i.e.
+
+        `ctx->b->triunsuitable_user_func = <YOUR FUNCTION PTR>`
+
+        The signature of the function is
+
+        `int (vertex triorg, vertex tridest, vertex triapex, REAL area)`
+
+        where the first three arguments represent the vertices of the
+        triangle and fourth argument represents the triangle's area.
+        The function should return 1 if the triangle is supposed to be
+        refined and 0 otherwise.
     -A  Assigns an additional floating-point attribute to each triangle
         that identifies what segment-bounded region each triangle belongs
         to.  Attributes are assigned to regions by the .poly file.  If a


### PR DESCRIPTION
Hi,

In the original triangle code it is possible to implement the 'triunsuitable' function in order to employ a user-defined criterion for triangle refinement if the 'u' program option is set. I have implemented a method to set a callback function using a function pointer to avoid that the library has to be recompiled when the function changes. This also required chaning line 7384 in triangle.c such that 'findcircumcenter' is used in favor of 'findNewSPLocation' if a user-function is employed. Otherwise, the refinement loop does not terminate in all cases (similar to when using b->fixedarea or b->vararea).

Best, Dan