### PR TITLE
Fix ctest project.

### DIFF
--- a/src/Triangle/triangle_api.h
+++ b/src/Triangle/triangle_api.h
@@ -32,7 +32,7 @@ extern "C" {
 
 	/**
 	 * Gets the Triangle version.
-	 * @param version Interger array of length 4 [major, minor, patch, has_acute].
+	 * @param version Integer array of length 4 [major, minor, patch, has_acute].
 	 */
 	EXPORT void triangle_version(int version[4]);
 	

--- a/src/examples/triangle-test/CMakeLists.txt
+++ b/src/examples/triangle-test/CMakeLists.txt
@@ -10,8 +10,10 @@ add_test(
    NAME triangle-test
    COMMAND triangle-test)
 
-add_custom_command(TARGET triangle-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy            
-        "$<TARGET_FILE_DIR:triangle-api>/$<TARGET_FILE_NAME:triangle-api>"
-        "$<TARGET_FILE_DIR:triangle-test>/$<TARGET_FILE_NAME:triangle-api>"
+if(WIN32)
+    add_custom_command(TARGET triangle-test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy            
+            "$<TARGET_FILE_DIR:triangle-api>/$<TARGET_FILE_NAME:triangle-api>"
+            "$<TARGET_FILE_DIR:triangle-test>/$<TARGET_FILE_NAME:triangle-api>"
 )
+endif()

--- a/src/examples/triangle-test/CMakeLists.txt
+++ b/src/examples/triangle-test/CMakeLists.txt
@@ -9,3 +9,9 @@ target_link_libraries(triangle-test PRIVATE Triangle::triangle-api)
 add_test(
    NAME triangle-test
    COMMAND triangle-test)
+
+add_custom_command(TARGET triangle-test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy            
+        "$<TARGET_FILE_DIR:triangle-api>/$<TARGET_FILE_NAME:triangle-api>"
+        "$<TARGET_FILE_DIR:triangle-test>/$<TARGET_FILE_NAME:triangle-api>"
+)

--- a/src/examples/triangle-test/CMakeLists.txt
+++ b/src/examples/triangle-test/CMakeLists.txt
@@ -15,5 +15,5 @@ if(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy            
             "$<TARGET_FILE_DIR:triangle-api>/$<TARGET_FILE_NAME:triangle-api>"
             "$<TARGET_FILE_DIR:triangle-test>/$<TARGET_FILE_NAME:triangle-api>"
-)
+    )
 endif()


### PR DESCRIPTION
@jzarl 

<del>By making the triangle-api project a shared library, commit d5cc0de20d12efcee0289694c480d807984c8462 probably broke ctest.</del> To make testing work, the shared library must be copied to the test target directory.

This works with Visual Studio. Before merging, I'd like to make sure that it also works with other compiler platforms.